### PR TITLE
Added a small note on how to install the sdk-app-collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 ## Installation:
 1. Clone the sdk-app-collection repo
 2. Move it to ```$SPLUNK_HOME/etc/apps/``` (where $SPLUNK_HOME is the path to your splunk directory)
+3. Restart splunk


### PR DESCRIPTION
There was no documentation on how to install the sdk-app-collection repo so I added a small note on how to install it in the README.md. This would make things easier for new hires.
